### PR TITLE
Add request to context

### DIFF
--- a/oscar_invoices/views.py
+++ b/oscar_invoices/views.py
@@ -23,5 +23,6 @@ class InvoicePreviewView(UserPassesTestMixin, SingleObjectMixin, View):
             legal_entity=invoice.legal_entity,
             order=invoice.order,
             use_path=False,
+            request=request,
         )
         return HttpResponse(rendered_invoice)


### PR DESCRIPTION
This is so we can get the site with get_settings template tag in multisites, right now it breaks; 
`No request found in context, and use_default_site flag not set`